### PR TITLE
switch from PySimpleGUI to FreeSimpleGUI due to new proprietary licence

### DIFF
--- a/Inti_ser_recon.py
+++ b/Inti_ser_recon.py
@@ -304,7 +304,7 @@ except ImportError :
     from serfilesreader import Serfile
 import stonyhurst as sth
 
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 try :
     import ctypes
 except:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ La liste des dépendances se trouve dans le fichier requirements.txt
 - opencv_python==4.4.0.46
 - numpy==1.19.2
 - astropy==4.2
-- PySimpleGUI==4.38.0
+- FreeSimpleGUI
 - lsq-ellipse==2.0.1
 - PyYAML==5.4.1
 - serfilesreader==0.0.6
@@ -143,7 +143,7 @@ The list of dependencies can be found in the file requirements.txt
 - opencv_python==4.4.0.46
 - numpy==1.19.2
 - astropy==4.2
-- PySimpleGUI==4.38.0
+- FreeSimpleGUI
 - lsq-ellipse==2.0.1
 
 For an automatic installation type :

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 opencv_python
 numpy
 astropy
-PySimpleGUI
+FreeSimpleGUI
 lsq-ellipse==2.0.1
 serfilesreader==0.0.6
 PyYAML
 scipy
 requests
+matplotlib
+
 


### PR DESCRIPTION
This Pull request switches from PySimpleGUI to FreeSimpleGUI.

Since the author of PySimpleGUI changed the license of PySimpleGUI to commecial and your program now starts with a nag screen, this PR circumvents that completely legally.

see the discussion here:

https://www.reddit.com/r/Python/comments/1d8d4iv/psa_pysimplegui_has_deleted_almost_all_old_lgpl/

regards
Philipp

